### PR TITLE
Add support for uploading avro schemas to schema registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,22 @@ addSbtPlugin("com.iadvize" % "sbt-avro" % "1.0.0-SNAPSHOT")
 
 ### Download Avro schema files from Schema Registry
 
-By default sbt-avro will download all Avro schema files from local schema registry to your default ressources_managed directory (ie: `target/scala-2.12/ressources_managed/main/avro/`). 
+By default sbt-avro will download all Avro schema files from local schema registry to your default resources_managed directory (ie: `target/scala-2.12/resources_managed/main/avro/`). 
 Please check settings section for more information about available settings.
 
 Example:
 ```scala
 sbt avro:download
+```
+
+### Upload Avro schema files to Schema Registry
+
+sbt-avro can upload all Avro Schema files from your resources directory (ie: `src/main/resources/avro`) to a local schema registry.
+Please check settings section for more information about available settings.
+
+Example:
+```scala
+sbt avro:upload
 ```
 
 ### Generate scala classes from Avro schema files
@@ -39,7 +49,6 @@ sbt avro:generate
 ```
 
 The case classes will get generated in your default src_managed directory (ie:`target/scala-2.12/src_managed/main/avro/`).
-
 
 ## Settings
 
@@ -92,4 +101,5 @@ object ${this.mangle($schema.getName())} extends Enumeration {
   
   - [Victor Pirat](https://github.com/atvictor)
   - [Jocelyn Dréan](https://github.com/jocelyndrean)
+  - [Ian Duffy](https://github.com/imduffy15)
   - You -> Submit your PR

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ organization := "com.iadvize"
 
 scalaVersion := "2.12.3"
 
+sbtPlugin := true
+
 publishTo := Some("Artifactory Realm" at "https://iadvize.jfrog.io/iadvize/iadvize-sbt")
 
 credentials += Credentials("Artifactory Realm", "iadvize.jfrog.io", sys.env.getOrElse("ARTIFACTORY_USERNAME", sys.props.getOrElse("ARTIFACTORY_USERNAME", "")), sys.env.getOrElse("ARTIFACTORY_PASS", sys.props.getOrElse("ARTIFACTORY_PASS", "")))
@@ -16,3 +18,10 @@ libraryDependencies ++= Seq(
   "org.apache.avro" % "avro-compiler"                % "1.8.2",
   "io.confluent"    % "kafka-schema-registry-client" % "3.3.0"
 )
+
+crossScalaVersions := Seq(scalaVersion.value, "2.11.11", "2.10.6")
+
+scriptedBufferLog := false
+scriptedLaunchOpts ++= Seq(
+  "-Xmx1024M",
+  s"-Dplugin.version=${version.value}")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.0
+sbt.version = 1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/com/iadvize/sbt/avro/AvroPlugin.scala
+++ b/src/main/scala/com/iadvize/sbt/avro/AvroPlugin.scala
@@ -84,7 +84,7 @@ object AvroPlugin extends AutoPlugin {
     lazy val Avro = config("avro") extend Compile
 
     val download = taskKey[Seq[File]]("Download schemas from the registry.")
-    val upload = taskKey[Unit]("Upload schemas to thee registry")
+    val upload = taskKey[Unit]("Upload schemas to the registry")
     val generate = taskKey[Seq[File]]("Generate Scala classes from schemas.")
 
     val schemaRegistryEndpoint = settingKey[String]("Schema registry endpoint, defaults to http://localhost:8081.")

--- a/src/main/scala/com/iadvize/sbt/avro/AvroPlugin.scala
+++ b/src/main/scala/com/iadvize/sbt/avro/AvroPlugin.scala
@@ -12,6 +12,7 @@ import org.apache.avro.compiler.specific.SpecificCompiler
 import scala.collection.JavaConverters._
 import sbt._
 import sbt.Keys._
+import sbt.internal.util.ManagedLogger
 
 import scala.util.Try
 
@@ -83,6 +84,7 @@ object AvroPlugin extends AutoPlugin {
     lazy val Avro = config("avro") extend Compile
 
     val download = taskKey[Seq[File]]("Download schemas from the registry.")
+    val upload = taskKey[Unit]("Upload schemas to thee registry")
     val generate = taskKey[Seq[File]]("Generate Scala classes from schemas.")
 
     val schemaRegistryEndpoint = settingKey[String]("Schema registry endpoint, defaults to http://localhost:8081.")
@@ -103,6 +105,7 @@ object AvroPlugin extends AutoPlugin {
     resourceDirectory := (resourceDirectory in Compile).value / directoryName.value,
     sourceManaged := (sourceManaged in Compile).value / directoryName.value,
     download := downloadTask.value,
+    upload := uploadTask.value,
     generate := generateTask.value,
 
     resourceGenerators in Compile += download.taskValue,
@@ -115,6 +118,8 @@ object AvroPlugin extends AutoPlugin {
   )
 
   lazy val downloadTask = Def.task {
+    val logger = streams.value.log
+
     val configuredSchemas = schemas.value
     val configuredResourceManaged = resourceManaged.value
     val configuredSchemaRegistryEndpoint = schemaRegistryEndpoint.value
@@ -125,7 +130,7 @@ object AvroPlugin extends AutoPlugin {
       schemaRegistryClient.getAllSubjects.asScala.map(subject => Schema(subject, Version.Last))
     } else configuredSchemas
 
-    streams.value.log.info("About to download:\n" + schemasToDownload.map(schema => "  " + schema.subject + " " + (if (schema.version == Version.Last) "latest" else "v" + schema.version)).mkString("\n") + "\nfrom " + configuredSchemaRegistryEndpoint)
+    logger.info("About to download:\n" + schemasToDownload.map(schema => "  " + schema.subject + " " + (if (schema.version == Version.Last) "latest" else "v" + schema.version)).mkString("\n") + "\nfrom " + configuredSchemaRegistryEndpoint)
 
     Files.createDirectories(configuredResourceManaged.toPath)
 
@@ -144,20 +149,28 @@ object AvroPlugin extends AutoPlugin {
       .toSeq
   }
 
+  lazy val uploadTask = Def.task {
+    val logger = streams.value.log
+
+    val configuredSchemaRegistryEndpoint = schemaRegistryEndpoint.value
+    val schemaRegistryClient = new CachedSchemaRegistryClient(configuredSchemaRegistryEndpoint, 10000)
+
+    val schemasToRegister = parseSchemas(logger, resourceDirectory.value.toPath)
+
+    schemasToRegister.foreach {
+      case(subject: String, (file: File, schema: avro.Schema)) =>
+        logger.info(s"Calling register $subject ${file.getAbsolutePath}")
+        schemaRegistryClient.register(subject, schema)
+    }
+  }
+
   lazy val generateTask = Def.task {
     val logger = streams.value.log
+
     val configuredSourceManaged = sourceManaged.value
 
-    val parser = new Parser()
-
-    def parseSchemas(path: Path) =
-      if (path.toFile.exists())
-        Files.newDirectoryStream(path, "*.avsc").iterator().asScala.flatMap { schemaPath =>
-          Try(parser.parse(schemaPath.toFile)).fold(throwable => { logger.error(s"Can't parse schema $schemaPath, got error: ${throwable.getMessage}"); None}, schema => Some(schema.getName -> (schemaPath.toFile, schema)))
-        }.toMap
-      else Map.empty[String, (File, avro.Schema)]
-
-    val schemasToGenerate = parseSchemas(resourceManaged.value.toPath) ++ parseSchemas(resourceDirectory.value.toPath)
+    val schemasToGenerate = parseSchemas(logger, resourceManaged.value.toPath) ++
+      parseSchemas(logger, resourceDirectory.value.toPath)
 
     Files.createDirectories(configuredSourceManaged.toPath)
 
@@ -167,6 +180,17 @@ object AvroPlugin extends AutoPlugin {
       compiler.setTemplateDir(classPathTemplatesDirectory.value)
       compiler.compileToDestinationWithResult(schemaFile, configuredSourceManaged).toSeq
     }.toSeq
+  }
+
+  private def parseSchemas(logger: ManagedLogger, path: Path) = {
+    val parser = new Parser()
+    if (path.toFile.exists())
+      Files.newDirectoryStream(path, "*.avsc").iterator().asScala.flatMap { schemaPath =>
+        Try(parser.parse(schemaPath.toFile)).fold(throwable => {
+          logger.error(s"Can't parse schema $schemaPath, got error: ${throwable.getMessage}"); None
+        }, schema => Some(schema.getName -> (schemaPath.toFile, schema)))
+      }.toMap
+    else Map.empty[String, (File, avro.Schema)]
   }
 
   override def requires = sbt.plugins.JvmPlugin

--- a/src/sbt-test/sbt-avro/simple/build.sbt
+++ b/src/sbt-test/sbt-avro/simple/build.sbt
@@ -1,0 +1,2 @@
+version := "0.1"
+scalaVersion := "2.12.3"

--- a/src/sbt-test/sbt-avro/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-avro/simple/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.iadvize" % """sbt-avro""" % pluginVersion)
+}

--- a/src/sbt-test/sbt-avro/simple/src/main/resources/avro/test.avsc
+++ b/src/sbt-test/sbt-avro/simple/src/main/resources/avro/test.avsc
@@ -1,0 +1,11 @@
+{
+  "namespace": "simple",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    }
+  ]
+}

--- a/src/sbt-test/sbt-avro/simple/test
+++ b/src/sbt-test/sbt-avro/simple/test
@@ -1,0 +1,5 @@
+> avro:upload
+> avro:download
+> avro:generate
+$ exists target/scala-2.12/resource_managed/main/avro/User.avsc
+$ exists target/scala-2.12/src_managed/main/avro/simple/User.scala


### PR DESCRIPTION
Adds support for uploading local avro schemas to a schema registry.

This is useful if you wish to version control avro schemas on git and
have your CI do the registration to schema registry.

Additionally, I've added tests using sbt scripted to test the plugin.
It requires a schema registry running on localhost:8081

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>