### PR TITLE
Test schema compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ Example:
 sbt avro:upload
 ```
 
+### Test compatibility of schemas with their latest versions in Schema Registry
+
+sbt-avro can test schemas for compatibility against the latest version of a subject's schema. This makes use of the 
+Schema Registry [compatibility](https://docs.confluent.io/current/schema-registry/docs/api.html#id1) resource.
+
+The plugin will look for `*.avsc` files in :
+- Resources folder (ie: `src/main/resources/avro/`)
+- Resources Managed folder (ie: `target/scala-2.12/resources_managed/main/avro/`)
+
+Example:
+```scala
+sbt avro:compatibility
+```
+
 ### Generate scala classes from Avro schema files
 
 The plugin sbt-avro will look for `*.avsc` files in :
@@ -79,6 +93,8 @@ Task                                    | Description
 ----------------------------------------|----------------------------------------
 download                                | Download Avro schemas from a Schema Registry
 generate                                | Generate case classes from avro files
+upload                                  | Upload Avro schemas to a Schema Registry
+compatibility                           | Test compatibility of Avro schemas against their latest versions in a Schema Registry
 
 Important: `sbt:compile` task will only call avro:generate and not call download task.
 

--- a/src/sbt-test/sbt-avro/simple/src/main/resources/test-incompatible.avsc
+++ b/src/sbt-test/sbt-avro/simple/src/main/resources/test-incompatible.avsc
@@ -1,0 +1,11 @@
+{
+  "namespace": "simple",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {
+      "name": "name",
+      "type": "int"
+    }
+  ]
+}

--- a/src/sbt-test/sbt-avro/simple/test
+++ b/src/sbt-test/sbt-avro/simple/test
@@ -3,3 +3,7 @@
 > avro:generate
 $ exists target/scala-2.12/resource_managed/main/avro/User.avsc
 $ exists target/scala-2.12/src_managed/main/avro/simple/User.scala
+> avro:compatibility
+$ delete src/main/resources/avro/test.avsc
+$ copy-file src/main/resources/test-incompatible.avsc src/main/resources/avro/test-incompatible.avsc
+-> avro:compatibility


### PR DESCRIPTION
This PR adds a `avro:compatibility` task which will test schemas for compatibility against the latest version of a subject's schema in a schema registry.

This would be useful if you wish to have your CI test compatibility of schema changes when PRs are raised/updated.

Fixes #3 